### PR TITLE
salt-master, salt-minion and DeepSea are now installed on the salt VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Vagrant will instantiate four VMs using an `opensuse/openSUSE-42.1-x86_64` box:
 
 | VM  |  IP | Description |
 |----------| ----------|----------|
-| `salt` | 192.168.100.200 | This VM will run [openattic-docker](https://github.com/openattic/openattic-docker) container (salt-master + salt-minion)|
+| `salt` | 192.168.100.200 | This VM will run [openattic-docker](https://github.com/openattic/openattic-docker) container or openattic (salt-master + salt-minion)|
 | `node1` | 192.168.100.201 | This VM will run ceph (salt-minion) |
 | `node2` | 192.168.100.202 | This VM will run ceph (salt-minion) |
 | `node3` | 192.168.100.203 | This VM will run ceph (salt-minion) |
@@ -44,24 +44,20 @@ Configuration resides in the `settings.yml` file that contains the custom config
 
 * Run `vagrant up && vagrant halt salt && vagrant up salt` and wait a few minutes
 * Connect to salt VM: `vagrant ssh salt`
-* Start openattic-docker: `oa-docker-run.sh`
+* Now you should choose if you want to use docker (1) or not (2)
+1) **Using docker**
+    * Start openattic-docker: `oa-docker-run.sh`
+    * Access openATTIC at: [http://192.168.100.200/openattic](http://192.168.100.200/openattic)
+    > You can execute `oa-docker-bash.sh` on `salt` VM to access openATTIC docker container    
 
-#### - Using docker
-* Start openattic-docker: `oa-docker-run.sh`
-* Access openATTIC at: [http://192.168.100.200/openattic](http://192.168.100.200/openattic)
-    
-##### Known limitations: 
-
-using docker will only work for ceph modules development and can't be used for local storage features development.
-For more information see [openattic-docker issue #9](https://github.com/openattic/openattic-docker/issues/9).
-
-> You can execute `oa-docker-bash.sh` on `salt` VM to access openATTIC docker container
-
-#### - Without using docker
-* Install openattic: `sudo oa-install.sh` **WARNING: (this will only work after [PR #695](https://bitbucket.org/openattic/openattic/pull-requests/695/support-for-ceph-on-vagrant-provision/diff) is merged)**
-* Activate virtual env: `. env/bin/activate`
-* Run server: `$ python openattic/backend/manage.py runserver 0.0.0.0:8001`
-* Access openATTIC at: [http://192.168.100.200:8001](http://192.168.100.200:8001)
+    **Known limitations**: 
+    using docker will only work for ceph modules development and can't be used for local storage features development.
+    For more information see [openattic-docker issue #9](https://github.com/openattic/openattic-docker/issues/9).
+2) **Without using docker**
+    * Install openattic: `sudo oa-install.sh` **WARNING: (this will only work after [PR #695](https://bitbucket.org/openattic/openattic/pull-requests/695/support-for-ceph-on-vagrant-provision/diff) is merged)**
+    * Activate virtual env: `. env/bin/activate`
+    * Run server: `$ python openattic/backend/manage.py runserver 0.0.0.0:8001`
+    * Access openATTIC at: [http://192.168.100.200:8001](http://192.168.100.200:8001)
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Configuration resides in the `settings.yml` file that contains the custom config
     using docker will only work for ceph modules development and can't be used for local storage features development.
     For more information see [openattic-docker issue #9](https://github.com/openattic/openattic-docker/issues/9).
 2) **Without using docker**
-    * Install openattic: `sudo oa-install.sh` **WARNING: (this will only work after [PR #695](https://bitbucket.org/openattic/openattic/pull-requests/695/support-for-ceph-on-vagrant-provision/diff) is merged)**
+    * Install openattic: `sudo bin/oa-install.sh` **WARNING: (this will only work after [PR #695](https://bitbucket.org/openattic/openattic/pull-requests/695/support-for-ceph-on-vagrant-provision/diff) is merged)**
     * Activate virtual env: `. env/bin/activate`
-    * Run server: `$ python openattic/backend/manage.py runserver 0.0.0.0:8001`
+    * Run server: `python openattic/backend/manage.py runserver 0.0.0.0:8001`
     * Access openATTIC at: [http://192.168.100.200:8001](http://192.168.100.200:8001)
 
 ## Running tests

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Configuration resides in the `settings.yml` file that contains the custom config
 #### - Using docker
 * Start openattic-docker: `oa-docker-run.sh`
 * Access openATTIC at: [http://192.168.100.200/openattic](http://192.168.100.200/openattic)
+    
+##### Known limitations: 
+
+using docker will only work for ceph modules development and can't be used for local storage features development.
+For more information see [openattic-docker issue #9](https://github.com/openattic/openattic-docker/issues/9).
 
 > You can execute `oa-docker-bash.sh` on `salt` VM to access openATTIC docker container
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Configuration resides in the `settings.yml` file that contains the custom config
     using docker will only work for ceph modules development and can't be used for local storage features development.
     For more information see [openattic-docker issue #9](https://github.com/openattic/openattic-docker/issues/9).
 2) **Without using docker**
-    * Install openattic: `sudo bin/oa-install.sh` **WARNING: (this will only work after [PR #695](https://bitbucket.org/openattic/openattic/pull-requests/695/support-for-ceph-on-vagrant-provision/diff) is merged)**
+    * Install openattic: `sudo bin/oa-install.sh`
     * Activate virtual env: `. env/bin/activate`
     * Run server: `python openattic/backend/manage.py runserver 0.0.0.0:8001`
     * Access openATTIC at: [http://192.168.100.200:8001](http://192.168.100.200:8001)

--- a/README.md
+++ b/README.md
@@ -45,9 +45,18 @@ Configuration resides in the `settings.yml` file that contains the custom config
 * Run `vagrant up && vagrant halt salt && vagrant up salt` and wait a few minutes
 * Connect to salt VM: `vagrant ssh salt`
 * Start openattic-docker: `oa-docker-run.sh`
+
+#### - Using docker
+* Start openattic-docker: `oa-docker-run.sh`
 * Access openATTIC at: [http://192.168.100.200/openattic](http://192.168.100.200/openattic)
 
 > You can execute `oa-docker-bash.sh` on `salt` VM to access openATTIC docker container
+
+#### - Without using docker
+* Install openattic: `sudo oa-install.sh` **WARNING: (this will only work after [PR #695](https://bitbucket.org/openattic/openattic/pull-requests/695/support-for-ceph-on-vagrant-provision/diff) is merged)**
+* Activate virtual env: `. env/bin/activate`
+* Run server: `$ python openattic/backend/manage.py runserver 0.0.0.0:8001`
+* Access openATTIC at: [http://192.168.100.200:8001](http://192.168.100.200:8001)
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Configuration resides in the `settings.yml` file that contains the custom config
 |----------| ----------| --------| --------|
 | `openattic_repo` | string | `~/openattic` | Path to the local copy of the openATTIC repository |
 | `deepsea_repo` | string | `~/DeepSea` | Path to the local copy of the DeepSea repository |
+| `openattic_docker_repo` | string | `https://github.com/openattic/openattic-docker.git` | openattic-docker git url |
+| `openattic_docker_branch` | string | `master` | openattic-docker git branch |
 | `libvirt_host` | IP address | none |  |
 | `libvirt_user` | string | none |  |
 | `libvirt_use_ssl` | boolean | none |  |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,17 +98,16 @@ Vagrant.configure("2") do |config|
       systemctl enable docker
       systemctl restart docker
 
-      zypper -n install ntp
+      zypper -n install ntp salt-minion salt-master
       systemctl enable ntpd
       systemctl start ntpd
 
-      zypper -n install salt-minion
+      systemctl enable salt-master
+      systemctl start salt-master
+      sleep 5
       systemctl enable salt-minion
       systemctl start salt-minion
 
-      zypper -n install salt-master
-      systemctl enable salt-master
-      systemctl start salt-master
 
       git clone https://github.com/openattic/openattic-docker.git
       cd openattic-docker

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,13 @@ openattic_repo = settings.has_key?('openattic_repo') ?
 deepsea_repo = settings.has_key?('deepsea_repo') ?
                settings['deepsea_repo'] : "~/DeepSea"
 
+openattic_docker_repo = settings.has_key?('openattic_docker_repo') ?
+                        settings['openattic_docker_repo'] :
+                        'https://github.com/openattic/openattic-docker.git'
+
+openattic_docker_branch = settings.has_key?('openattic_docker_branch') ?
+                          settings['openattic_docker_branch'] : 'master'
+
 num_volumes = settings.has_key?('vm_num_volumes') ?
               settings['vm_num_volumes'] : 2
 
@@ -110,9 +117,9 @@ Vagrant.configure("2") do |config|
       systemctl start salt-minion
 
 
-      git clone https://github.com/openattic/openattic-docker.git
+      git clone #{openattic_docker_repo} openattic-docker
       cd openattic-docker
-      git checkout master
+      git checkout #{openattic_docker_branch}
       cd openattic-dev/opensuse_leap_42.2
       docker build -t openattic-dev .
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -210,8 +210,6 @@ EOF
     end
 
     node.vm.provision "shell", inline: <<-SHELL
-      SuSEfirewall2 off
-
       echo "192.168.100.200 salt" >> /etc/hosts
       echo "192.168.100.201 node1" >> /etc/hosts
       echo "192.168.100.202 node2" >> /etc/hosts
@@ -226,6 +224,8 @@ EOF
       zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
       zypper --gpg-auto-import-keys ref
+
+      SuSEfirewall2 off
 
       zypper -n install ntp
       zypper -n install salt-minion
@@ -265,8 +265,6 @@ EOF
     end
 
     node.vm.provision "shell", inline: <<-SHELL
-      SuSEfirewall2 off
-
       echo "192.168.100.200 salt" >> /etc/hosts
       echo "192.168.100.201 node1" >> /etc/hosts
       echo "192.168.100.202 node2" >> /etc/hosts
@@ -285,6 +283,8 @@ EOF
       zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
       zypper --gpg-auto-import-keys ref
+
+      SuSEfirewall2 off
 
       zypper -n install ntp
       zypper -n install salt-minion
@@ -324,8 +324,6 @@ EOF
     end
 
     node.vm.provision "shell", inline: <<-SHELL
-      SuSEfirewall2 off
-
       echo "192.168.100.200 salt" >> /etc/hosts
       echo "192.168.100.201 node1" >> /etc/hosts
       echo "192.168.100.202 node2" >> /etc/hosts
@@ -345,6 +343,7 @@ EOF
       zypper --gpg-auto-import-keys ref
       hostname node3
 
+      SuSEfirewall2 off
 
       zypper -n install ntp
       zypper -n install salt-minion

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,12 @@ Vagrant.configure("2") do |config|
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
 
+    salt.vm.provider "libvirt" do |lv|
+      (1..num_volumes).each do |d|
+        lv.storage :file, size: volume_size, type: 'raw', :bus => 'scsi'
+      end
+    end
+
     salt.vm.provision "shell", inline: <<-SHELL
       echo "192.168.100.200 salt" >> /etc/hosts
       echo "192.168.100.201 node1" >> /etc/hosts

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -148,11 +148,11 @@ EOF
 
         chown -R salt:salt /srv/pillar
         systemctl restart salt-master
-        sleep 5
+        sleep 10
         echo "[DeepSea] Stage 0 - prep"
         salt-run state.orch ceph.stage.prep
 
-        sleep 5
+        sleep 10
         echo "[DeepSea] Installing and Activating Salt-API"
         salt-call state.apply ceph.cherrypy
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -186,7 +186,7 @@ EOF
         salt-run state.orch ceph.stage.configure
         sleep 5
         echo "[DeepSea] Stage 3 - deploy"
-        DEPLOY_ENV='dev' salt-run state.orch ceph.stage.deploy
+        DEV_ENV='true' salt-run state.orch ceph.stage.deploy
       fi
     SHELL
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -133,7 +133,6 @@ Vagrant.configure("2") do |config|
       cd /home/vagrant/DeepSea
       if [[ -e Makefile ]]; then
         make install
-        sed -i "s/_REPLACE_ME_/`hostname -f`/" /srv/pillar/ceph/master_minion.sls
         sed -i -e 's/v\.storage()/#v.storage()/g' -e 's/v\.ganesha()/#v.ganesha()/g' /srv/modules/runners/validate.py
 
         cat > /srv/salt/ceph/updates/default_my.sls <<EOF

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,6 +84,7 @@ Vagrant.configure("2") do |config|
       chmod 600 /home/vagrant/.ssh/id_rsa
       cp /home/vagrant/.ssh/id_rsa* /root/.ssh/
       cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+      hostname salt
 
       chmod 755 -R bin/
 
@@ -220,6 +221,7 @@ EOF
       chmod 600 /home/vagrant/.ssh/id_rsa
       cp /home/vagrant/.ssh/id_rsa* /root/.ssh/
       cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+      hostname node1
 
       zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
@@ -274,6 +276,7 @@ EOF
       chmod 600 /home/vagrant/.ssh/id_rsa
       cp /home/vagrant/.ssh/id_rsa* /root/.ssh/
       cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+      hostname node2
 
       ssh-keyscan -H salt >> ~/.ssh/known_hosts
       ssh-keyscan -H node1 >> ~/.ssh/known_hosts
@@ -340,6 +343,8 @@ EOF
       zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
       zypper --gpg-auto-import-keys ref
+      hostname node3
+
 
       zypper -n install ntp
       zypper -n install salt-minion

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -193,6 +193,8 @@ EOF
         sleep 5
         echo "[DeepSea] Stage 3 - deploy"
         DEV_ENV='true' salt-run state.orch ceph.stage.deploy
+
+        chmod 644 /etc/ceph/ceph.client.admin.keyring
       fi
     SHELL
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,161 +57,6 @@ Vagrant.configure("2") do |config|
     vb.cpus = settings.has_key?('vm_cpus') ? settings['vm_cpus'] : 2
   end
 
-  config.vm.define :salt do |salt|
-    salt.vm.hostname = "salt"
-    salt.vm.network :private_network, ip: "192.168.100.200"
-
-    salt.vm.provision "file", source: "keys/id_rsa",
-                              destination:".ssh/id_rsa"
-    salt.vm.provision "file", source: "keys/id_rsa.pub",
-                              destination:".ssh/id_rsa.pub"
-
-    salt.vm.provision "file", source: "bin",
-                              destination:"."
-
-    salt.vm.synced_folder openattic_repo, '/home/vagrant/openattic', type: 'nfs',
-                            :nfs_export => nfs_auto_export,
-                            :mount_options => ['nolock,vers=3,udp,noatime,actimeo=1'],
-                            :linux__nfs_options => ['rw','no_subtree_check','all_squash','insecure']
-
-    salt.vm.synced_folder deepsea_repo, '/home/vagrant/DeepSea', type: 'nfs',
-                            :nfs_export => nfs_auto_export,
-                            :mount_options => ['nolock,vers=3,udp,noatime,actimeo=1'],
-                            :linux__nfs_options => ['rw','no_subtree_check','all_squash','insecure']
-
-    config.vm.synced_folder ".", "/vagrant", disabled: true
-
-    salt.vm.provider "libvirt" do |lv|
-      (1..num_volumes).each do |d|
-        lv.storage :file, size: volume_size, type: 'raw', :bus => 'scsi'
-      end
-    end
-    salt.vm.provider :virtualbox do |vb|
-      for i in 1..num_volumes do
-        file_to_disk = "./disks/#{salt.vm.hostname}-disk#{i}.vmdk"
-        unless File.exist?(file_to_disk)
-          vb.customize ['createmedium', 'disk', '--filename', file_to_disk,
-            '--size', volume_size]
-          vb.customize ['storageattach', :id,
-            '--storagectl', 'SATA Controller',
-            '--port', i, '--device', 0,
-            '--type', 'hdd', '--medium', file_to_disk]
-        end
-      end
-    end
-
-    salt.vm.provision "shell", inline: <<-SHELL
-      echo "192.168.100.200 salt" >> /etc/hosts
-      echo "192.168.100.201 node1" >> /etc/hosts
-      echo "192.168.100.202 node2" >> /etc/hosts
-      echo "192.168.100.203 node3" >> /etc/hosts
-      cat /home/vagrant/.ssh/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys
-      mkdir /root/.ssh
-      chmod 600 /home/vagrant/.ssh/id_rsa
-      cp /home/vagrant/.ssh/id_rsa* /root/.ssh/
-      cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
-      hostname salt
-
-      chmod 755 -R bin/
-
-      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
-      zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
-      zypper --gpg-auto-import-keys ref
-      zypper ar https://yum.dockerproject.org/repo/main/opensuse/13.2/ docker-main
-      zypper --no-gpg-checks ref
-      zypper -n --no-gpg-checks install docker-engine
-      zypper rr docker-main
-
-      systemctl enable docker
-      systemctl restart docker
-
-      zypper -n install ntp salt-minion salt-master
-      systemctl enable ntpd
-      systemctl start ntpd
-
-      systemctl enable salt-master
-      systemctl start salt-master
-      sleep 5
-      systemctl enable salt-minion
-      systemctl start salt-minion
-
-
-      git clone #{openattic_docker_repo} openattic-docker
-      cd openattic-docker
-      git checkout #{openattic_docker_branch}
-      cd openattic-dev/opensuse_leap_42.2
-      docker build -t openattic-dev .
-
-      SuSEfirewall2 off
-
-      while : ; do
-        PROVISIONED_NODES=`ls -l /tmp/ready-* 2>/dev/null | wc -l`
-        echo "waiting for node1, node2 and node3 (${PROVISIONED_NODES}/3)";
-        [[ "${PROVISIONED_NODES}" != "3" ]] || break
-        sleep 2;
-        scp -o StrictHostKeyChecking=no node2:/tmp/ready /tmp/ready-node1;
-        scp -o StrictHostKeyChecking=no node2:/tmp/ready /tmp/ready-node2;
-        scp -o StrictHostKeyChecking=no node3:/tmp/ready /tmp/ready-node3;
-      done
-
-      salt-key -Ay
-
-      cd /home/vagrant/DeepSea
-      if [[ -e Makefile ]]; then
-        make install
-
-        cat > /srv/salt/ceph/updates/default_my.sls <<EOF
-dummy command:
-  test.nop
-EOF
-        cp /srv/salt/ceph/updates/default_my.sls /srv/salt/ceph/updates/restart
-        sed -i 's/default/default_my/g' /srv/salt/ceph/updates/init.sls
-        sed -i 's/default/default_my/g' /srv/salt/ceph/updates/restart/init.sls
-        cp /srv/salt/ceph/updates/default_my.sls /srv/salt/ceph/time
-        sed -i 's/default/default_my/g' /srv/salt/ceph/time/init.sls
-
-        chown -R salt:salt /srv/pillar
-        systemctl restart salt-master
-        sleep 10
-        echo "[DeepSea] Stage 0 - prep"
-        salt-run state.orch ceph.stage.prep
-
-        sleep 10
-        echo "[DeepSea] Installing and Activating Salt-API"
-        salt-call state.apply ceph.cherrypy
-
-        sleep 10
-        echo "[DeepSea] Stage 1 - discovery"
-        salt-run state.orch ceph.stage.discovery
-        cat > /srv/pillar/ceph/proposals/policy.cfg <<EOF
-# Cluster assignment
-cluster-ceph/cluster/*.sls
-# Hardware Profile
-profile-*-1/cluster/*.sls
-profile-*-1/stack/default/ceph/minions/*yml
-# Common configuration
-config/stack/default/global.yml
-config/stack/default/ceph/cluster.yml
-# Role assignment
-role-master/cluster/salt.sls
-role-admin/cluster/salt.sls
-role-mon/cluster/node*.sls
-role-igw/cluster/node[12]*.sls
-role-mon/stack/default/ceph/minions/node*.yml
-EOF
-        chown salt:salt /srv/pillar/ceph/proposals/policy.cfg
-        sleep 2
-        echo "[DeepSea] Stage 2 - configure"
-        salt-run state.orch ceph.stage.configure
-        sleep 5
-        echo "[DeepSea] Stage 3 - deploy"
-        DEV_ENV='true' salt-run state.orch ceph.stage.deploy
-
-        chmod 644 /etc/ceph/ceph.client.admin.keyring
-      fi
-    SHELL
-  end
-
   config.vm.define :node1 do |node|
     node.vm.hostname = "node1"
     node.vm.network :private_network, ip: "192.168.100.201"
@@ -385,4 +230,159 @@ EOF
     SHELL
   end
 
+  config.vm.define :salt do |salt|
+    salt.vm.hostname = "salt"
+    salt.vm.network :private_network, ip: "192.168.100.200"
+
+    salt.vm.provision "file", source: "keys/id_rsa",
+                              destination:".ssh/id_rsa"
+    salt.vm.provision "file", source: "keys/id_rsa.pub",
+                              destination:".ssh/id_rsa.pub"
+
+    salt.vm.provision "file", source: "bin",
+                              destination:"."
+
+    salt.vm.synced_folder openattic_repo, '/home/vagrant/openattic', type: 'nfs',
+                            :nfs_export => nfs_auto_export,
+                            :mount_options => ['nolock,vers=3,udp,noatime,actimeo=1'],
+                            :linux__nfs_options => ['rw','no_subtree_check','all_squash','insecure']
+
+    salt.vm.synced_folder deepsea_repo, '/home/vagrant/DeepSea', type: 'nfs',
+                            :nfs_export => nfs_auto_export,
+                            :mount_options => ['nolock,vers=3,udp,noatime,actimeo=1'],
+                            :linux__nfs_options => ['rw','no_subtree_check','all_squash','insecure']
+
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+
+    salt.vm.provider "libvirt" do |lv|
+      (1..num_volumes).each do |d|
+        lv.storage :file, size: volume_size, type: 'raw', :bus => 'scsi'
+      end
+    end
+    salt.vm.provider :virtualbox do |vb|
+      for i in 1..num_volumes do
+        file_to_disk = "./disks/#{salt.vm.hostname}-disk#{i}.vmdk"
+        unless File.exist?(file_to_disk)
+          vb.customize ['createmedium', 'disk', '--filename', file_to_disk,
+            '--size', volume_size]
+          vb.customize ['storageattach', :id,
+            '--storagectl', 'SATA Controller',
+            '--port', i, '--device', 0,
+            '--type', 'hdd', '--medium', file_to_disk]
+        end
+      end
+    end
+
+    salt.vm.provision "shell", inline: <<-SHELL
+      echo "192.168.100.200 salt" >> /etc/hosts
+      echo "192.168.100.201 node1" >> /etc/hosts
+      echo "192.168.100.202 node2" >> /etc/hosts
+      echo "192.168.100.203 node3" >> /etc/hosts
+      cat /home/vagrant/.ssh/id_rsa.pub >> /home/vagrant/.ssh/authorized_keys
+      mkdir /root/.ssh
+      chmod 600 /home/vagrant/.ssh/id_rsa
+      cp /home/vagrant/.ssh/id_rsa* /root/.ssh/
+      cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+      hostname salt
+
+      chmod 755 -R bin/
+
+      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
+      zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
+      zypper --gpg-auto-import-keys ref
+      zypper ar https://yum.dockerproject.org/repo/main/opensuse/13.2/ docker-main
+      zypper --no-gpg-checks ref
+      zypper -n --no-gpg-checks install docker-engine
+      zypper rr docker-main
+
+      systemctl enable docker
+      systemctl restart docker
+
+      zypper -n install ntp salt-minion salt-master
+      systemctl enable ntpd
+      systemctl start ntpd
+
+      systemctl enable salt-master
+      systemctl start salt-master
+      sleep 5
+      systemctl enable salt-minion
+      systemctl start salt-minion
+
+
+      git clone #{openattic_docker_repo} openattic-docker
+      cd openattic-docker
+      git checkout #{openattic_docker_branch}
+      cd openattic-dev/opensuse_leap_42.2
+      docker build -t openattic-dev .
+
+      SuSEfirewall2 off
+
+      while : ; do
+        PROVISIONED_NODES=`ls -l /tmp/ready-* 2>/dev/null | wc -l`
+        echo "waiting for node1, node2 and node3 (${PROVISIONED_NODES}/3)";
+        [[ "${PROVISIONED_NODES}" != "3" ]] || break
+        sleep 2;
+        scp -o StrictHostKeyChecking=no node2:/tmp/ready /tmp/ready-node1;
+        scp -o StrictHostKeyChecking=no node2:/tmp/ready /tmp/ready-node2;
+        scp -o StrictHostKeyChecking=no node3:/tmp/ready /tmp/ready-node3;
+      done
+
+      salt-key -Ay
+
+      cd /home/vagrant/DeepSea
+      if [[ -e Makefile ]]; then
+        make install
+
+        cat > /srv/salt/ceph/updates/default_my.sls <<EOF
+dummy command:
+  test.nop
+EOF
+        cp /srv/salt/ceph/updates/default_my.sls /srv/salt/ceph/updates/restart
+        sed -i 's/default/default_my/g' /srv/salt/ceph/updates/init.sls
+        sed -i 's/default/default_my/g' /srv/salt/ceph/updates/restart/init.sls
+        cp /srv/salt/ceph/updates/default_my.sls /srv/salt/ceph/time
+        sed -i 's/default/default_my/g' /srv/salt/ceph/time/init.sls
+
+        chown -R salt:salt /srv/pillar
+        systemctl restart salt-master
+        sleep 10
+        echo "[DeepSea] Stage 0 - prep"
+        salt-run state.orch ceph.stage.prep
+
+        sleep 10
+        echo "[DeepSea] Installing and Activating Salt-API"
+        salt-call state.apply ceph.cherrypy
+
+        sleep 10
+        echo "[DeepSea] Stage 1 - discovery"
+        salt-run state.orch ceph.stage.discovery
+        cat > /srv/pillar/ceph/proposals/policy.cfg <<EOF
+# Cluster assignment
+cluster-ceph/cluster/*.sls
+# Hardware Profile
+profile-*-1/cluster/*.sls
+profile-*-1/stack/default/ceph/minions/*yml
+# Common configuration
+config/stack/default/global.yml
+config/stack/default/ceph/cluster.yml
+# Role assignment
+role-master/cluster/salt.sls
+role-admin/cluster/salt.sls
+role-mon/cluster/node*.sls
+role-igw/cluster/node[12]*.sls
+role-mon/stack/default/ceph/minions/node*.yml
+EOF
+        chown salt:salt /srv/pillar/ceph/proposals/policy.cfg
+        sleep 2
+        echo "[DeepSea] Stage 2 - configure"
+        salt-run state.orch ceph.stage.configure
+        sleep 5
+        echo "[DeepSea] Stage 3 - deploy"
+        DEV_ENV='true' salt-run state.orch ceph.stage.deploy
+
+        chmod 644 /etc/ceph/ceph.client.admin.keyring
+      fi
+    SHELL
+  end
+  
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -137,13 +137,13 @@ Vagrant.configure("2") do |config|
 
         cat > /srv/salt/ceph/updates/default_my.sls <<EOF
 dummy command:
-  cmd.run:
-    - name: "ls"
-    - shell: /bin/bash
+  test.nop
 EOF
         cp /srv/salt/ceph/updates/default_my.sls /srv/salt/ceph/updates/restart
         sed -i 's/default/default_my/g' /srv/salt/ceph/updates/init.sls
         sed -i 's/default/default_my/g' /srv/salt/ceph/updates/restart/init.sls
+        cp /srv/salt/ceph/updates/default_my.sls /srv/salt/ceph/time
+        sed -i 's/default/default_my/g' /srv/salt/ceph/time/init.sls
 
         chown -R salt:salt /srv/pillar
         systemctl restart salt-master

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,6 +86,19 @@ Vagrant.configure("2") do |config|
         lv.storage :file, size: volume_size, type: 'raw', :bus => 'scsi'
       end
     end
+    salt.vm.provider :virtualbox do |vb|
+      for i in 1..num_volumes do
+        file_to_disk = "./disks/#{salt.vm.hostname}-disk#{i}.vmdk"
+        unless File.exist?(file_to_disk)
+          vb.customize ['createmedium', 'disk', '--filename', file_to_disk,
+            '--size', volume_size]
+          vb.customize ['storageattach', :id,
+            '--storagectl', 'SATA Controller',
+            '--port', i, '--device', 0,
+            '--type', 'hdd', '--medium', file_to_disk]
+        end
+      end
+    end
 
     salt.vm.provision "shell", inline: <<-SHELL
       echo "192.168.100.200 salt" >> /etc/hosts

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -133,7 +133,6 @@ Vagrant.configure("2") do |config|
       cd /home/vagrant/DeepSea
       if [[ -e Makefile ]]; then
         make install
-        sed -i -e 's/v\.storage()/#v.storage()/g' -e 's/v\.ganesha()/#v.ganesha()/g' /srv/modules/runners/validate.py
 
         cat > /srv/salt/ceph/updates/default_my.sls <<EOF
 dummy command:
@@ -180,7 +179,7 @@ EOF
         salt-run state.orch ceph.stage.configure
         sleep 5
         echo "[DeepSea] Stage 3 - deploy"
-        salt-run state.orch ceph.stage.deploy
+        DEPLOY_ENV='dev' salt-run state.orch ceph.stage.deploy
       fi
     SHELL
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -151,6 +151,11 @@ EOF
         sleep 5
         echo "[DeepSea] Stage 0 - prep"
         salt-run state.orch ceph.stage.prep
+
+        sleep 5
+        echo "[DeepSea] Installing and Activating Salt-API"
+        salt-call state.apply ceph.cherrypy
+
         sleep 10
         echo "[DeepSea] Stage 1 - discovery"
         salt-run state.orch ceph.stage.discovery

--- a/bin/oa-docker-bash.sh
+++ b/bin/oa-docker-bash.sh
@@ -1,1 +1,1 @@
-sudo docker exec -ti `sudo docker ps -qa` bash
+sudo docker exec -ti `sudo docker ps -qa | head -1` bash

--- a/bin/oa-docker-run.sh
+++ b/bin/oa-docker-run.sh
@@ -1,13 +1,5 @@
-# TODO destroy ceph cluster if exists
-
-for i in 1 2 3; do
-  ssh node$i 'sudo rm /etc/salt/pki/minion/minion_master.pub'
-  ssh node$i 'sudo systemctl restart salt-minion'
-done
-
 sudo docker run -t \
   -v /home/vagrant/openattic:/srv/openattic \
-  -v /home/vagrant/DeepSea:/srv/deepsea \
   -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
   -v /etc/ceph:/etc/ceph \
   --net=host \

--- a/bin/oa-install.sh
+++ b/bin/oa-install.sh
@@ -1,0 +1,3 @@
+pushd /home/vagrant
+./openattic/vagrant/install.sh --disable-ceph-repo
+popd


### PR DESCRIPTION
salt-master, salt-minion and DeepSea are now installed on the salt VM (instead of being installed on openattic-docker).

With this change, openattic-docker branch "wip-deepsea" can be removed.

Signed-off-by: Ricardo Marques <rimarques@suse.com>