### PR TITLE
Opensuse 42.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -256,25 +256,6 @@ Vagrant.configure("2") do |config|
 
     config.vm.synced_folder ".", "/vagrant", disabled: true
 
-    salt.vm.provider "libvirt" do |lv|
-      (1..num_volumes).each do |d|
-        lv.storage :file, size: volume_size, type: 'raw', :bus => 'scsi'
-      end
-    end
-    salt.vm.provider :virtualbox do |vb|
-      for i in 1..num_volumes do
-        file_to_disk = "./disks/#{salt.vm.hostname}-disk#{i}.vmdk"
-        unless File.exist?(file_to_disk)
-          vb.customize ['createmedium', 'disk', '--filename', file_to_disk,
-            '--size', volume_size]
-          vb.customize ['storageattach', :id,
-            '--storagectl', 'SATA Controller',
-            '--port', i, '--device', 0,
-            '--type', 'hdd', '--medium', file_to_disk]
-        end
-      end
-    end
-
     salt.vm.provision "shell", inline: <<-SHELL
       echo "192.168.100.200 salt" >> /etc/hosts
       echo "192.168.100.201 node1" >> /etc/hosts

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ nfs_auto_export = settings.has_key?('nfs_auto_export') ?
 Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
-  config.vm.box = "opensuse/openSUSE-42.1-x86_64"
+  config.vm.box = "opensuse/openSUSE-42.2-x86_64"
 
   config.vm.provider "libvirt" do |lv|
     if settings.has_key?('libvirt_host') then
@@ -99,7 +99,7 @@ Vagrant.configure("2") do |config|
       cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
       hostname node1
 
-      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
+      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.2/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
       zypper --gpg-auto-import-keys ref
 
@@ -158,7 +158,7 @@ Vagrant.configure("2") do |config|
       ssh-keyscan -H node1 >> ~/.ssh/known_hosts
       ssh-keyscan -H node3 >> ~/.ssh/known_hosts
 
-      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
+      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.2/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
       zypper --gpg-auto-import-keys ref
 
@@ -216,7 +216,7 @@ Vagrant.configure("2") do |config|
       ssh-keyscan -H node1 >> ~/.ssh/known_hosts
       ssh-keyscan -H node2 >> ~/.ssh/known_hosts
 
-      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
+      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.2/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
       zypper --gpg-auto-import-keys ref
       hostname node3
@@ -289,7 +289,7 @@ Vagrant.configure("2") do |config|
 
       chmod 755 -R bin/
 
-      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.1/filesystems:ceph:jewel.repo
+      zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.2/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
       zypper --gpg-auto-import-keys ref
       zypper ar https://yum.dockerproject.org/repo/main/opensuse/13.2/ docker-main


### PR DESCRIPTION
Upgrade Vagrant box to openSUSE-42.2 and removes disks from salt node.