### PR TITLE
Rgw

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Configuration resides in the `settings.yml` file that contains the custom config
 | `vm_num_volumes` | integer |  `2`| VM volumes number |
 | `vm_volume_size` |  binary size | `8G`| VM volume size |
 | `nfs_auto_export` | boolean | `true` | Enables/disables vagrant from changing the contents of `/etc/exports`
-| `build_openattic_docker_image` | boolean | `true` | Enables/disables the build of the openattic docker image during provisioning
+| `build_openattic_docker_image` | boolean | `false` | Enables/disables the build of the openattic docker image during provisioning
 
 ### Spin up cluster
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Vagrant will instantiate four VMs using an `opensuse/openSUSE-42.2-x86_64` box:
 | VM  |  IP | Roles | Description |
 |----------| ----------|----------| ----------|
 | `salt` | 192.168.100.200 | **master**, **admin** |Run [openattic-docker](https://github.com/openattic/openattic-docker) container or openattic (salt-master + salt-minion)|
-| `node1` | 192.168.100.201 | **mon**, **igw** | Run ceph (salt-minion) |
+| `node1` | 192.168.100.201 | **mon**, **igw**, **rgw** | Run ceph (salt-minion) |
 | `node2` | 192.168.100.202 | **mon**, **igw** | Run ceph (salt-minion) |
-| `node3` | 192.168.100.203 | **mon** | Run ceph (salt-minion) |
+| `node3` | 192.168.100.203 | **mon**, **rgw** | Run ceph (salt-minion) |
 
 ## Requirements
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,7 @@ nfs_auto_export = settings.has_key?('nfs_auto_export') ?
                   settings['nfs_auto_export'] : true
 
 build_openattic_docker_image = settings.has_key?('build_openattic_docker_image') ?
-                               settings['build_openattic_docker_image'] : true
+                               settings['build_openattic_docker_image'] : false
 
 Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
@@ -313,6 +313,7 @@ Vagrant.configure("2") do |config|
         scp -o StrictHostKeyChecking=no node3:/tmp/ready /tmp/ready-node3;
       done
 
+      sleep 5
       salt-key -Ay
 
       cd /home/vagrant/DeepSea

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -356,9 +356,17 @@ role-master/cluster/salt.sls
 role-admin/cluster/salt.sls
 role-mon/cluster/node*.sls
 role-igw/cluster/node[12]*.sls
+role-rgw/cluster/node[13]*.sls
 role-mon/stack/default/ceph/minions/node*.yml
 EOF
         chown salt:salt /srv/pillar/ceph/proposals/policy.cfg
+        cat > /srv/pillar/ceph/rgw.sls <<EOF
+rgw_configurations:
+  rgw:
+    users:
+      - { uid: "admin", name: "Admin", email: "admin@demo.nil", system: True }
+EOF
+        chown salt:salt /srv/pillar/ceph/rgw.sls
         sleep 2
         echo "[DeepSea] Stage 2 - configure"
         salt-run state.orch ceph.stage.configure

--- a/bin/curl-salt-api.sh
+++ b/bin/curl-salt-api.sh
@@ -1,0 +1,13 @@
+RED='\033[0;31m'
+NC='\033[0m'
+
+if [ $# -eq 0 ]
+  then
+    echo ""
+    echo -e "${RED}Usage: $0 <function>${NC}" 1>&2
+    echo ""
+    echo "Example: $0 ui_iscsi.interfaces "
+  else
+    curl -sSk http://salt:8000/login -c /tmp/ds-runner-cookies.txt -H 'Accept: application/x-yaml' -d username=admin -d password=admin -d eauth=auto
+    curl -sSk http://salt:8000 -b /tmp/ds-runner-cookies.txt -H 'Accept: application/x-yaml' -d client=runner -d fun=$1
+fi

--- a/bin/oa-docker-run.sh
+++ b/bin/oa-docker-run.sh
@@ -1,3 +1,9 @@
+if [[ "$(sudo docker images -q openattic-dev 2> /dev/null)" == "" ]]; then
+  pushd /home/vagrant/openattic-docker/openattic-dev/opensuse_leap_42.2
+  sudo docker build --network=host -t openattic-dev .
+  popd
+fi
+
 for container in $(sudo docker ps -qa); do
   sudo docker rm -f $container
 done


### PR DESCRIPTION
- Configure `RGW nodes`
- Change default value of `build_openattic_docker_image` to false (docker build will be executed by `oa-run.sh` if needed)
- Added `curl-salt-api.sh` script to call salt-api runner via curl