### PR TITLE
The number of nodes is configurable by 'num_nodes' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Vagrant will instantiate four VMs using an `opensuse/openSUSE-42.2-x86_64` box:
 |----------| ----------|----------| ----------|
 | `salt` | 192.168.100.200 | **master**, **admin** |Run [openattic-docker](https://github.com/openattic/openattic-docker) container or openattic (salt-master + salt-minion)|
 | `node1` | 192.168.100.201 | **mon**, **igw**, **rgw**, **mgr** | Run ceph (salt-minion) |
-| `node2` | 192.168.100.202 | **mon**, **igw**, **mgr** | Run ceph (salt-minion) |
-| `node3` | 192.168.100.203 | **mon**, **rgw** | Run ceph (salt-minion) |
+| `node2` | 192.168.100.202 | **mon**, **igw**, **ganesha**, **mgr** | Run ceph (salt-minion) |
+| `node3` | 192.168.100.203 | **mon**, **rgw**, **ganesha** | Run ceph (salt-minion) |
 
 ## Requirements
 
@@ -41,6 +41,7 @@ Configuration resides in the `settings.yml` file that contains the custom config
 | `nfs_auto_export` | boolean | `true` | Enables/disables vagrant from changing the contents of `/etc/exports`
 | `build_openattic_docker_image` | boolean | `false` | Enables/disables the build of the openattic docker image during provisioning
 | `create_openattic_node` | boolean | `false` | Creates a new node to test openATTIC installations through zypper/rpm
+| `num_nodes` | integer | `3` | The number of nodes 
 
 ### Spin up cluster
 


### PR DESCRIPTION
This PR makes the number of nodes configurable by the setting `num_nodes`.
Currently, the supported number of nodes are `2` or `3` (default).

The usage of a two node cluster is not recommended, but is useful if we want to create a cluster on a system with low memory 
(e.g. If the machine has 8GiB, and each node has 2GiB, the cluster will need 6GiB)

This PR was inspired on [PR 10](https://github.com/ricardoasmarques/vagrant-openattic-docker/pull/10), by @sebastian-philipp

Signed-off-by: Ricardo Marques <rimarques@suse.com>