### PR TITLE
Added missing zypper repositories

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -117,6 +117,8 @@ Vagrant.configure("2") do |config|
 
       zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.2/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
+      zypper ar http://download.opensuse.org/repositories/home:/tserong/openSUSE_Factory/home:tserong.repo
+      zypper ar http://download.opensuse.org/repositories/home:/jfajerski/openSUSE_Leap_42.2/home:jfajerski.repo
       zypper --gpg-auto-import-keys ref
 
       SuSEfirewall2 off
@@ -180,6 +182,8 @@ Vagrant.configure("2") do |config|
 
         zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.2/filesystems:ceph:jewel.repo
         zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
+        zypper ar http://download.opensuse.org/repositories/home:/tserong/openSUSE_Factory/home:tserong.repo
+        zypper ar http://download.opensuse.org/repositories/home:/jfajerski/openSUSE_Leap_42.2/home:jfajerski.repo
         zypper --gpg-auto-import-keys ref
 
         SuSEfirewall2 off
@@ -243,6 +247,8 @@ Vagrant.configure("2") do |config|
 
         zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.2/filesystems:ceph:jewel.repo
         zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
+        zypper ar http://download.opensuse.org/repositories/home:/tserong/openSUSE_Factory/home:tserong.repo
+        zypper ar http://download.opensuse.org/repositories/home:/jfajerski/openSUSE_Leap_42.2/home:jfajerski.repo
         zypper --gpg-auto-import-keys ref
         hostname node3
 
@@ -358,6 +364,8 @@ Vagrant.configure("2") do |config|
 
       zypper ar http://download.opensuse.org/repositories/filesystems:/ceph:/jewel/openSUSE_Leap_42.2/filesystems:ceph:jewel.repo
       zypper ar http://download.opensuse.org/repositories/home:/swiftgist/openSUSE_Leap_42.1/home:swiftgist.repo
+      zypper ar http://download.opensuse.org/repositories/home:/tserong/openSUSE_Factory/home:tserong.repo
+      zypper ar http://download.opensuse.org/repositories/home:/jfajerski/openSUSE_Leap_42.2/home:jfajerski.repo
       zypper --gpg-auto-import-keys ref
       zypper ar https://yum.dockerproject.org/repo/main/opensuse/13.2/ docker-main
       zypper --no-gpg-checks ref


### PR DESCRIPTION
Required to install 'golang-github-prometheus-prometheus' and 'grafana-dashboards-ceph' packages

Signed-off-by: Ricardo Marques <rimarques@suse.com>