### PR TITLE
Add a script to run all django unit tests

### DIFF
--- a/bin/oa-docker-django-unit-tests.sh
+++ b/bin/oa-docker-django-unit-tests.sh
@@ -1,0 +1,8 @@
+sudo docker run -t \
+  -v /home/vagrant/openattic:/srv/openattic \
+  -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+  --net=host --privileged \
+  --security-opt seccomp=unconfined \
+  --stop-signal=SIGRTMIN+3 \
+  --tmpfs /run/lock --rm \
+  openattic-dev tests


### PR DESCRIPTION
This PR adds a script to run all django unit tests.

Signed-off-by: Ricardo Marques <rimarques@suse.com>